### PR TITLE
If postIds, friendIds etc are int[] we can't call ->remove() on the array

### DIFF
--- a/tests/Tests/Persistence/Db/Integration/Domains/Fixtures/Blog/TestUser.php
+++ b/tests/Tests/Persistence/Db/Integration/Domains/Fixtures/Blog/TestUser.php
@@ -156,8 +156,8 @@ class TestUser extends Entity
      */
     public function makeFriends(TestUser $otherUser)
     {
-        $this->friendIds->addRange($otherUser->getId());
-        $otherUser->friendIds->addRange($this->getId());
+        $this->friendIds->addRange([$otherUser->getId()]);
+        $otherUser->friendIds->addRange([$this->getId()]);
     }
 
     /**
@@ -181,6 +181,6 @@ class TestUser extends Entity
     {
         $post->authorId = $otherUser->getId();
         $this->postIds->remove($post->getId());
-        $otherUser->postIds->addRange($post->getId());
+        $otherUser->postIds->addRange([$post->getId()]);
     }
 }

--- a/tests/Tests/Persistence/Db/Integration/Domains/Fixtures/Blog/TestUser.php
+++ b/tests/Tests/Persistence/Db/Integration/Domains/Fixtures/Blog/TestUser.php
@@ -48,17 +48,17 @@ class TestUser extends Entity
     public $status;
 
     /**
-     * @var EntityIdCollection|int[]
+     * @var EntityIdCollection
      */
     public $postIds;
 
     /**
-     * @var EntityIdCollection|int[]
+     * @var EntityIdCollection
      */
     public $friendIds;
 
     /**
-     * @var EntityIdCollection|int[]
+     * @var EntityIdCollection
      */
     public $commentIds;
 
@@ -156,8 +156,8 @@ class TestUser extends Entity
      */
     public function makeFriends(TestUser $otherUser)
     {
-        $this->friendIds[]      = $otherUser->getId();
-        $otherUser->friendIds[] = $this->getId();
+        $this->friendIds->addRange($otherUser->getId());
+        $otherUser->friendIds->addRange($this->getId());
     }
 
     /**
@@ -181,6 +181,6 @@ class TestUser extends Entity
     {
         $post->authorId = $otherUser->getId();
         $this->postIds->remove($post->getId());
-        $otherUser->postIds[] = $post->getId();
+        $otherUser->postIds->addRange($post->getId());
     }
 }


### PR DESCRIPTION
Hi, 

I have been looking into the code, and it looks to me, if this is an array of int, then the call on `unfriend` will not work.

Correct me if I am wrong.

> NB : Nice mapper, so far I like it.